### PR TITLE
Import htmltools HTML and magrittr pipe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,10 +13,12 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
-Imports: 
+Imports:
     scales (>= 1.2.1),
     dplyr,
-    tidyr
-Suggests: 
+    tidyr,
+    htmltools,
+    magrittr
+Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,1 +1,3 @@
 exportPattern("^[[:alpha:]]+")
+importFrom(htmltools,HTML)
+importFrom(magrittr,"%>%")

--- a/R/Html.R
+++ b/R/Html.R
@@ -6,6 +6,8 @@
 #' @return Una cadena de texto que contiene \code{<br/>} repetido \code{n} veces.
 #' @examples
 #' Saltos(3)  # Devuelve "<br/><br/><br/>"
+#' @importFrom htmltools HTML
+#' @importFrom magrittr %>%
 #' @export
 Saltos <- function(n = 1) {
   strrep('<br/>', n) %>% HTML()


### PR DESCRIPTION
## Summary
- import HTML from htmltools and %>% from magrittr for HTML helper functions
- declare htmltools and magrittr in DESCRIPTION
- add corresponding imports to NAMESPACE

## Testing
- `R CMD check --no-manual --as-cran .` *(fails: Required fields missing or empty: 'Author' 'Maintainer')*


------
https://chatgpt.com/codex/tasks/task_e_68b6e7d8827c833188cd48fb5f6b1c7d