### PR TITLE
Import dplyr case_when and use gt without require

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,9 +13,10 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.2
-Imports: 
+Imports:
     scales (>= 1.2.1),
     dplyr,
+    gt,
     tidyr
 Suggests: 
     testthat (>= 3.0.0)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,1 +1,5 @@
 exportPattern("^[[:alpha:]]+")
+import(scales)
+import(shiny)
+import(gt)
+importFrom(dplyr, case_when)

--- a/R/Formatos.R
+++ b/R/Formatos.R
@@ -198,9 +198,9 @@ FormatearTexto <- function(x, negrita = TRUE, color = "#000000", tamano_pct = 1,
 #' library(gt)
 #' gt(head(mtcars)) %>% gt_minimal_style()
 #'
+#' @import gt
 #' @export
 gt_minimal_style <- function(gt_table) {
-  require(gt)
 
   gt_table %>%
     # Opciones generales de la tabla
@@ -266,6 +266,7 @@ gt_minimal_style <- function(gt_table) {
 #' col_kpi(1, TRUE)
 #' col_kpi(-1, FALSE)
 #'
+#' @importFrom dplyr case_when
 #' @export
 col_kpi <- function(x, prop = TRUE) {
   case_when(
@@ -289,6 +290,7 @@ col_kpi <- function(x, prop = TRUE) {
 #' chr_kpi(1)
 #' chr_kpi(-1)
 #'
+#' @importFrom dplyr case_when
 #' @export
 chr_kpi <- function(x) {
   case_when(
@@ -311,6 +313,7 @@ chr_kpi <- function(x) {
 #' col_num(-3)
 #' col_num(c(5, -3, 0))
 #'
+#' @importFrom dplyr case_when
 #' @export
 col_num <- function(x) {
   case_when(


### PR DESCRIPTION
## Summary
- Import `case_when` from dplyr in formatting helpers
- Replace `require(gt)` with roxygen import and add `gt` to package metadata
- Declare necessary imports in `NAMESPACE`

## Testing
- `R -q -e "sessionInfo()"` *(fails: cannot find system Renviron)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e7cd4a00833192514090b84f894f