### PR TITLE
fix: update InputNumerico examples

### DIFF
--- a/R/Inputs.R
+++ b/R/Inputs.R
@@ -11,13 +11,13 @@
 #' @return Un objeto de tipo `fluidRow` con el diseño del input.
 #' @examples
 #' # Ejemplo para un input de dinero
-#' InputGenerico("dinero_input", "Monto:", 1000, type = "dinero")
-#'
+#' InputNumerico("dinero_input", "Monto:", 1000, type = "dinero")
+#' 
 #' # Ejemplo para un input de porcentaje
-#' InputGenerico("porcentaje_input", "Porcentaje:", 50, type = "porcentaje")
-#'
+#' InputNumerico("porcentaje_input", "Porcentaje:", 50, type = "porcentaje")
+#' 
 #' # Ejemplo para un input numérico general
-#' InputGenerico("numero_input", "Cantidad:", 10, max = 100, min = 0, dec = 3, type = "numero")
+#' InputNumerico("numero_input", "Cantidad:", 10, max = 100, min = 0, dec = 3, type = "numero")
 InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, type = "numero") {
   # Configuración específica según el tipo de input
   config <- switch(type,

--- a/man/InputNumerico.Rd
+++ b/man/InputNumerico.Rd
@@ -37,11 +37,11 @@ Crear un input numérico estilizado para Shiny
 }
 \examples{
 # Ejemplo para un input de dinero
-InputGenerico("dinero_input", "Monto:", 1000, type = "dinero")
+InputNumerico("dinero_input", "Monto:", 1000, type = "dinero")
 
 # Ejemplo para un input de porcentaje
-InputGenerico("porcentaje_input", "Porcentaje:", 50, type = "porcentaje")
+InputNumerico("porcentaje_input", "Porcentaje:", 50, type = "porcentaje")
 
 # Ejemplo para un input numérico general
-InputGenerico("numero_input", "Cantidad:", 10, max = 100, min = 0, dec = 3, type = "numero")
+InputNumerico("numero_input", "Cantidad:", 10, max = 100, min = 0, dec = 3, type = "numero")
 }


### PR DESCRIPTION
## Summary
- fix InputNumerico roxygen examples to reference the correct function name
- regenerate InputNumerico documentation

## Testing
- `R -q -e "devtools::document()"`
- `R -q -e "devtools::check(document = FALSE)"` *(fails: running examples for CajaIco requires darken)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e7bd2b8c8331a7d2fa39ec452b85