### PR TITLE
Validate InputNumerico type and namespace shiny components

### DIFF
--- a/R/Inputs.R
+++ b/R/Inputs.R
@@ -7,6 +7,9 @@
 #' @param max Valor máximo permitido (por defecto NULL).
 #' @param min Valor mínimo permitido (por defecto NULL).
 #' @param type Tipo de input: "dinero", "porcentaje" o "numero".
+#' @param label_col Ancho de la columna para la etiqueta (por defecto 6).
+#' @param input_col Ancho de la columna para el campo numérico (por defecto 6).
+#' @param width Ancho del control `autonumericInput` (por defecto "100%").
 #'
 #' @return Un objeto de tipo `fluidRow` con el diseño del input.
 #' @examples
@@ -18,7 +21,9 @@
 #' 
 #' # Ejemplo para un input numérico general
 #' InputNumerico("numero_input", "Cantidad:", 10, max = 100, min = 0, dec = 3, type = "numero")
-InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, type = "numero") {
+InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, type = "numero", label_col = 6, input_col = 6, width = "100%") {
+  type <- match.arg(type, c("dinero", "porcentaje", "numero"))
+
   # Configuración específica según el tipo de input
   config <- switch(type,
                    dinero = list(currencySymbol = "$", decimalPlaces = dec, max = max, min = min),
@@ -27,9 +32,9 @@ InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, typ
                    stop("Tipo de input no soportado. Use 'dinero', 'porcentaje' o 'numero'."))
 
   # Construcción del componente visual
-  res <- fluidRow(
-    column(6, FormatearTexto(label, tamano_pct = 0.8)),
-    column(6, autonumericInput(
+  res <- shiny::fluidRow(
+    shiny::column(label_col, FormatearTexto(label, tamano_pct = 0.8)),
+    shiny::column(input_col, shiny::autonumericInput(
       id,
       label = NULL,
       value = value,
@@ -38,7 +43,7 @@ InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, typ
       currencySymbol = config$currencySymbol,
       currencySymbolPlacement = config$currencySymbolPlacement,
       decimalPlaces = config$decimalPlaces,
-      width = "100%",
+      width = width,
       style = "height: 25px !important; font-size: 14px;"
     ))
   )

--- a/man/InputNumerico.Rd
+++ b/man/InputNumerico.Rd
@@ -11,7 +11,10 @@ InputNumerico(
   dec = 2,
   max = NULL,
   min = NULL,
-  type = "numero"
+  type = "numero",
+  label_col = 6,
+  input_col = 6,
+  width = "100%"
 )
 }
 \arguments{
@@ -28,6 +31,12 @@ InputNumerico(
 \item{min}{Valor mínimo permitido (por defecto NULL).}
 
 \item{type}{Tipo de input: "dinero", "porcentaje" o "numero".}
+
+\item{label_col}{Ancho de la columna para la etiqueta (por defecto 6).}
+
+\item{input_col}{Ancho de la columna para el campo numérico (por defecto 6).}
+
+\item{width}{Ancho del control `autonumericInput` (por defecto "100%").}
 }
 \value{
 Un objeto de tipo `fluidRow` con el diseño del input.


### PR DESCRIPTION
## Summary
- Ensure `InputNumerico` validates the `type` argument and allows custom column widths and input width.
- Namespace `fluidRow`, `column`, and `autonumericInput` with `shiny::`.
- Document new parameters in `InputNumerico`.

## Testing
- `R CMD check .` *(fails: Required fields missing or empty: 'Author' 'Maintainer')*


------
https://chatgpt.com/codex/tasks/task_e_68b6f1e2e6408331a3e00c6fbb415314