### PR TITLE
Qualify case_when usage in KPI helpers

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
 exportPattern("^[[:alpha:]]+")
+importFrom(dplyr,case_when)
 importFrom(htmltools,HTML)
 importFrom(magrittr,"%>%")

--- a/R/Formatos.R
+++ b/R/Formatos.R
@@ -262,7 +262,7 @@ gt_minimal_style <- function(gt_table) {
 #'
 #' @export
 col_kpi <- function(x, prop = TRUE) {
-  case_when(
+  dplyr::case_when(
     x == 0 ~ "#000000",
     prop & x > 0 ~ "#0B5345",
     prop & x < 0 ~ "#943126",
@@ -285,7 +285,7 @@ col_kpi <- function(x, prop = TRUE) {
 #'
 #' @export
 chr_kpi <- function(x) {
-  case_when(
+  dplyr::case_when(
     x == 0 ~ "▬",
     x > 0 ~ "▲",
     x < 0 ~ "▼"
@@ -307,7 +307,7 @@ chr_kpi <- function(x) {
 #'
 #' @export
 col_num <- function(x) {
-  case_when(
+  dplyr::case_when(
     x >= 0 ~ "#000000",
     x < 0 ~ "#943126"
   )


### PR DESCRIPTION
## Summary
- Prefix `case_when` calls with `dplyr::case_when` in KPI helper functions
- Import `case_when` from dplyr in NAMESPACE

## Testing
- ⚠️ `R CMD check --no-manual .` (missing package metadata)
- ⚠️ `R -q -e "install.packages('dplyr', repos='https://cloud.r-project.org')"` (repository unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68b6f1d376688331ab23b3717bfbbe23