### PR TITLE
Refactor recoding helpers to use tidy evaluation

### DIFF
--- a/man/TopAbsoluto.Rd
+++ b/man/TopAbsoluto.Rd
@@ -17,9 +17,9 @@ TopAbsoluto(
 \arguments{
 \item{data}{El conjunto de datos en el cual se encuentra la variable a recodificar.}
 
-\item{var_recode}{El nombre de la variable que se desea recodificar.}
+\item{var_recode}{Variable que se desea recodificar. Se pasa sin comillas.}
 
-\item{var_top}{El nombre de la variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen.}
+\item{var_top}{Variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen. Se pasa sin comillas.}
 
 \item{fun_Top}{La función de resumen a aplicar en caso de no utilizar las frecuencias absolutas (por ejemplo, "mean", "sum", etc.).}
 

--- a/man/TopRelativo.Rd
+++ b/man/TopRelativo.Rd
@@ -17,9 +17,9 @@ TopRelativo(
 \arguments{
 \item{data}{El conjunto de datos en el cual se encuentra la variable a recodificar.}
 
-\item{var_recode}{El nombre de la variable que se desea recodificar.}
+\item{var_recode}{Variable que se desea recodificar. Se pasa sin comillas.}
 
-\item{var_top}{El nombre de la variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen.}
+\item{var_top}{Variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen. Se pasa sin comillas.}
 
 \item{fun_Top}{La función de resumen a aplicar en caso de no utilizar las frecuencias absolutas (por ejemplo, "mean", "sum", etc.).}
 


### PR DESCRIPTION
## Summary
- refactor `TopAbsoluto` and `TopRelativo` to use tidy evaluation and `group_by(across(all_of()))`
- use `case_when` instead of nested `ifelse` when creating `nom_var`
- document `var_recode` and `var_top` as unquoted symbols

## Testing
- `R -q -e "devtools::document()"` *(fails: there is no package called 'devtools')*
- `R -q -e "install.packages('roxygen2', repos='https://cloud.r-project.org')"` *(fails: package 'roxygen2' is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f1cdacd48331ab6e1f3d058b0711