### PR TITLE
Handle NA and empty strings in EsNumero

### DIFF
--- a/R/Texto.R
+++ b/R/Texto.R
@@ -171,15 +171,20 @@ EsEnteroPositivo <- function(s) {
 #'
 #' @param cadena Cadena de texto a evaluar.
 #' @return
-#' `TRUE` si la cadena representa un número positivo,
-#' `FALSE` en caso contrario.
+#' Un vector lógico del mismo largo que `cadena`: `TRUE` si la cadena
+#' representa un número positivo y `FALSE` en caso contrario. Para valores
+#' `NA` y cadenas vacías se devuelve `FALSE`.
 #' @examples
 #' EsNumero("123")      # TRUE
 #' EsNumero("12.34")    # TRUE
 #' EsNumero("-5")       # FALSE
 #' EsNumero("abc")      # FALSE
+#' EsNumero(NA)         # FALSE
+#' EsNumero("")         # FALSE
 EsNumero <- function(cadena) {
-  es_valido <- grepl("^\\d*\\.?\\d+$", cadena) && as.numeric(cadena) > 0
+  es_valido <- grepl("^\\d*\\.?\\d+$", cadena) &
+    suppressWarnings(!is.na(as.numeric(cadena))) &
+    suppressWarnings(as.numeric(cadena) > 0)
   return(es_valido)
 }
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Este repositorio contiene un paquete de R creado específicamente para **Racafé
 ```r
 # EsEnteroPositivo("123")
 ```
-- `EsNumero(cadena)`: Comprueba si la cadena es un número positivo.
+- `EsNumero(cadena)`: Comprueba si la cadena es un número positivo. Los valores `NA` y las cadenas vacías retornan `FALSE`.
 ```r
 # EsNumero("12.3")
+# EsNumero("")
+# EsNumero(NA)
 ```
 - `EsNumTelefono(tel)`: Verifica si una cadena corresponde a un número de teléfono válido.
 ```r

--- a/man/EsNumero.Rd
+++ b/man/EsNumero.Rd
@@ -10,8 +10,7 @@ EsNumero(cadena)
 \item{cadena}{Cadena de texto a evaluar.}
 }
 \value{
-`TRUE` si la cadena representa un número positivo,
-`FALSE` en caso contrario.
+Un vector lógico del mismo largo que `cadena`: `TRUE` si la cadena representa un número positivo y `FALSE` en caso contrario. Para valores `NA` y cadenas vacías se devuelve `FALSE`.
 }
 \description{
 Comprueba si una cadena representa un número positivo válido (entero o decimal).
@@ -21,4 +20,6 @@ EsNumero("123")      # TRUE
 EsNumero("12.34")    # TRUE
 EsNumero("-5")       # FALSE
 EsNumero("abc")      # FALSE
+EsNumero(NA)         # FALSE
+EsNumero("")         # FALSE
 }


### PR DESCRIPTION
## Summary
- Ensure EsNumero uses vectorized logical operations with warning-suppressed numeric conversion
- Document EsNumero's `NA` and empty-string behavior
- Clarify README examples for EsNumero

## Testing
- `R -q -e 'source("R/Texto.R"); EsNumero(c("123","12.34","-5","abc",NA,""))'`
- `R CMD check --no-manual .` *(fails: Required fields missing or empty: 'Author' 'Maintainer')*

------
https://chatgpt.com/codex/tasks/task_e_68bb0bffbd408331adc72684f47ffcc2