### PR TITLE
Refactor top recoding helpers and add tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(racafe)
+
+test_check("racafe")

--- a/tests/testthat/test-top.R
+++ b/tests/testthat/test-top.R
@@ -1,0 +1,13 @@
+test_that("TopAbsoluto recodifica categorias menos frecuentes", {
+  datos <- data.frame(cat = c("A","A","B","B","C","D"), val = 1:6)
+  res <- TopAbsoluto(datos, var_recode = cat, var_top = val, fun_Top = "n", n = 2, nom_var = "cat_top")
+  expect_equal(as.character(res$cat_top), c("A","A","B","B","OTROS","OTROS"))
+  expect_equal(levels(res$cat_top), c("A","B","OTROS"))
+})
+
+test_that("TopRelativo aplica umbral porcentual", {
+  datos <- data.frame(cat = c("A","A","B","B","C"), val = c(10,5,4,1,1))
+  res <- TopRelativo(datos, var_recode = cat, var_top = val, fun_Top = "sum", pct_min = 0.2, nom_var = "cat_top")
+  expect_equal(as.character(res$cat_top), c("A","A","B","B","OTROS"))
+  expect_equal(levels(res$cat_top), c("A","B","OTROS"))
+})


### PR DESCRIPTION
## Summary
- Factor out common logic for absolute and relative top recoding into internal `.top_auxiliar`
- Update `TopAbsoluto` and `TopRelativo` to use shared helper
- Add unit tests covering both top recoding approaches

## Testing
- `R -q -e "source('R/Datos.R'); testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_68bb0bee3fbc833199fb279c7a978812