### PR TITLE
Valida límites numéricos en InputNumerico

### DIFF
--- a/R/Inputs.R
+++ b/R/Inputs.R
@@ -24,12 +24,27 @@
 InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, type = "numero", label_col = 6, input_col = 6, width = "100%") {
   type <- match.arg(type, c("dinero", "porcentaje", "numero"))
 
+  # Validaciones de tipo de datos
+  stopifnot(is.numeric(value))
+  if (!is.null(max)) stopifnot(is.numeric(max))
+  if (!is.null(min)) stopifnot(is.numeric(min))
+
   # Configuración específica según el tipo de input
   config <- switch(type,
                    dinero = list(currencySymbol = "$", decimalPlaces = dec, max = max, min = min),
                    porcentaje = list(currencySymbol = "%", currencySymbolPlacement = "s", decimalPlaces = 2, max = 100, min = 0),
                    numero = list(currencySymbol = NULL, decimalPlaces = dec, max = max, min = min),
                    stop("Tipo de input no soportado. Use 'dinero', 'porcentaje' o 'numero'."))
+
+  # Validaciones de rangos
+  if (!is.null(config$min) && !is.null(config$max)) {
+    stopifnot(config$min <= config$max)
+    stopifnot(config$min <= value, value <= config$max)
+  } else if (!is.null(config$min)) {
+    stopifnot(config$min <= value)
+  } else if (!is.null(config$max)) {
+    stopifnot(value <= config$max)
+  }
 
   # Construcción del componente visual
   res <- shiny::fluidRow(

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(racafe)
+
+test_check("racafe")

--- a/tests/testthat/test-inputs.R
+++ b/tests/testthat/test-inputs.R
@@ -1,0 +1,13 @@
+source(file.path("..", "..", "R", "Inputs.R"))
+
+test_that("InputNumerico valida argumentos numéricos", {
+  expect_error(InputNumerico("id", "label", "a"), "is\\.numeric\\(value\\)")
+  expect_error(InputNumerico("id", "label", 1, max = "10"), "is\\.numeric\\(max\\)")
+  expect_error(InputNumerico("id", "label", 1, min = "10"), "is\\.numeric\\(min\\)")
+})
+
+test_that("InputNumerico aplica límites", {
+  expect_error(InputNumerico("id", "label", 5, max = 4), "value <= config\\$max")
+  expect_error(InputNumerico("id", "label", 5, min = 6), "config\\$min <= value")
+  expect_error(InputNumerico("id", "label", 5, min = 6, max = 3), "config\\$min <= config\\$max")
+})


### PR DESCRIPTION
## Summary
- Valida que `value`, `max` y `min` sean numéricos
- Comprueba que `value` respete los límites definidos
- Añade pruebas para entradas no numéricas y valores fuera de rango

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'`

------
https://chatgpt.com/codex/tasks/task_e_68bb0c18dbec8331b6227bd02bac37b2