### PR TITLE
Include numeric day in FechaTexto and add tests

### DIFF
--- a/R/Fechas.R
+++ b/R/Fechas.R
@@ -34,8 +34,8 @@ PrimerDia <- function(x, uni = "month") {
 #' @return Un vector de cadenas de texto que representa las fechas en el formato especificado.
 #'
 #' @examples
-#' FechaTexto(as.Date(c("2023-10-15", "2022-05-22")))
-#' FechaTexto(as.Date(c("2023-10-15", "2022-05-22")), dia_nombre = FALSE)
+#' FechaTexto(as.Date("2023-10-15"), dia = TRUE)
+#' FechaTexto(as.Date("2023-10-15"), dia = TRUE, dia_nombre = FALSE)
 #' @export
 FechaTexto <- function(x, dia = TRUE, dia_nombre = TRUE, dia_nom_abr = TRUE,
                        mes = TRUE, mes_abr = TRUE, anho = TRUE,
@@ -72,7 +72,18 @@ FechaTexto <- function(x, dia = TRUE, dia_nombre = TRUE, dia_nom_abr = TRUE,
   d <- ifelse(dia, lubridate::day(x), NA)
 
   # Construcción del resultado
-  res <- paste(dn, paste(m, y, sep = ifelse(sep_texto, " de ", "")), sep = ifelse(sep_texto, ", ", ""))
+  construir <- function(dn, d, m, y) {
+    partes_fecha <- c()
+    if (!is.na(d)) partes_fecha <- c(partes_fecha, d)
+    if (!is.na(m)) partes_fecha <- c(partes_fecha, m)
+    if (!is.na(y)) partes_fecha <- c(partes_fecha, y)
+    fecha_txt <- paste(partes_fecha, collapse = ifelse(sep_texto, ' de ', ''))
+    partes_totales <- c()
+    if (!is.na(dn)) partes_totales <- c(partes_totales, dn)
+    if (fecha_txt != '') partes_totales <- c(partes_totales, fecha_txt)
+    paste(partes_totales, collapse = ifelse(sep_texto && length(partes_totales) > 1, ', ', ''))
+  }
+  res <- mapply(construir, dn, d, m, y, USE.NAMES = FALSE)
 
   # Retornar el resultado
   return(res)

--- a/man/FechaTexto.Rd
+++ b/man/FechaTexto.Rd
@@ -42,6 +42,6 @@ Un vector de cadenas de texto que representa las fechas en el formato especifica
 Esta función convierte una fecha en un formato de texto personalizado, permitiendo seleccionar qué partes de la fecha mostrar (día, mes, año).
 }
 \examples{
-FechaTexto(as.Date(c("2023-10-15", "2022-05-22")))
-FechaTexto(as.Date(c("2023-10-15", "2022-05-22")), dia_nombre = FALSE)
+FechaTexto(as.Date("2023-10-15"), dia = TRUE)
+FechaTexto(as.Date("2023-10-15"), dia = TRUE, dia_nombre = FALSE)
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(racafe)
+
+test_check("racafe")

--- a/tests/testthat/test-fecha-texto.R
+++ b/tests/testthat/test-fecha-texto.R
@@ -1,0 +1,13 @@
+source(file.path('..', '..', 'R', 'Fechas.R'))
+
+test_that('incluye día numérico cuando dia = TRUE', {
+  resultado <- FechaTexto(as.Date('2023-10-15'), dia = TRUE, dia_nombre = TRUE,
+                           mes_abr = TRUE, anho_abr = TRUE)
+  expect_equal(resultado, 'dom, 15 de Oct de 23')
+})
+
+test_that('omite día numérico cuando dia = FALSE', {
+  resultado <- FechaTexto(as.Date('2023-10-15'), dia = FALSE, dia_nombre = TRUE,
+                           mes_abr = TRUE, anho_abr = TRUE)
+  expect_equal(resultado, 'dom, Oct de 23')
+})


### PR DESCRIPTION
## Summary
- include numeric day in FechaTexto output while respecting parameter order
- document examples showing day number when `dia = TRUE`
- add tests covering formats with and without day numbers

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'`
- `R -q -e 'roxygen2::roxygenise()'` *(fails: The packages "odbc", "gt", and "plotly" are required)*
- `apt-get install -y r-cran-odbc r-cran-gt r-cran-plotly` *(fails: Unable to locate packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c01fce083319243f3cbc7cfaa22