### PR TITLE
docs: reorganizar secciones en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,6 @@ Este repositorio contiene un paquete de R creado específicamente para **Racafé
 # pick_opt(letters[1:5])
 ```
 
-### Librerías
-- `Loadpkg(pkg)`: Instala (si es necesario) y carga paquetes de R.
-```r
-# Loadpkg(c("ggplot2", "dplyr"))
-```
-
 ### Numéricos
 - `SiError_0(x)`: Reemplaza valores `NaN` e infinitos por 0.
 ```r
@@ -196,3 +190,10 @@ Este repositorio contiene un paquete de R creado específicamente para **Racafé
 ```r
 # ImprimeSankey(df, c("Var1", "Var2"), "n", colores = c("blue", "green"))
 ```
+
+### Librerías
+- `Loadpkg(pkg)`: Instala (si es necesario) y carga paquetes de R.
+```r
+# Loadpkg(c("ggplot2", "dplyr"))
+```
+


### PR DESCRIPTION
## Summary
- Reordenar secciones posteriores a `### Inputs` y documentar funciones numéricas, de salida y de librerías

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(falla: there is no package called 'testthat')*
- `R -q -e "install.packages('testthat', repos='https://cloud.r-project.org')"` *(falla: cannot open URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bb13d290cc8331847640f03421d3a3