### PR TITLE
Fix UTF-8 encoding in Datos docs

### DIFF
--- a/R/Datos.R
+++ b/R/Datos.R
@@ -540,9 +540,9 @@ LeerExcelDesdeOneDrive <- function(archivo_id, usuario, ...) {
 #'
 #' @param data El conjunto de datos en el cual se encuentra la variable a recodificar.
 #' @param var_recode Variable que se desea recodificar. Se pasa sin comillas.
-#' @param var_top Variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen. Se pasa sin comillas.
+#' @param var_top Variable a partir de la cual se calcularán las frecuencias o la función de resumen. Se pasa sin comillas.
 #' @param fun_Top La función de resumen a aplicar en caso de no utilizar las frecuencias absolutas (por ejemplo, "mean", "sum", etc.).
-#' @param n El número mÃ¡ximo de categorías principales a conservar (predeterminado: 10).
+#' @param n El número máximo de categorías principales a conservar (predeterminado: 10).
 #' @param nom_var El nombre para la nueva variable recodificada.
 #' @param lab_recodificar El nombre o etiqueta para las categorías recodificadas (predeterminado: "OTROS").
 #' @return El conjunto de datos con la variable recodificada según las categorías principales y las categorías recodificadas.
@@ -561,7 +561,7 @@ TopAbsoluto <- function(data, var_recode, var_top, fun_Top, n = 10, nom_var, lab
 #'
 #' @param data El conjunto de datos en el cual se encuentra la variable a recodificar.
 #' @param var_recode Variable que se desea recodificar. Se pasa sin comillas.
-#' @param var_top Variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen. Se pasa sin comillas.
+#' @param var_top Variable a partir de la cual se calcularán las frecuencias o la función de resumen. Se pasa sin comillas.
 #' @param fun_Top La función de resumen a aplicar en caso de no utilizar las frecuencias absolutas (por ejemplo, "mean", "sum", etc.).
 #' @param pct_min El porcentaje mínimo necesario para considerar una categoría principal (predeterminado: 0.05).
 #' @param nom_var El nombre para la nueva variable recodificada.

--- a/man/TopAbsoluto.Rd
+++ b/man/TopAbsoluto.Rd
@@ -19,11 +19,11 @@ TopAbsoluto(
 
 \item{var_recode}{Variable que se desea recodificar. Se pasa sin comillas.}
 
-\item{var_top}{Variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen. Se pasa sin comillas.}
+\item{var_top}{Variable a partir de la cual se calcularán las frecuencias o la función de resumen. Se pasa sin comillas.}
 
 \item{fun_Top}{La función de resumen a aplicar en caso de no utilizar las frecuencias absolutas (por ejemplo, "mean", "sum", etc.).}
 
-\item{n}{El número mÃ¡ximo de categorías principales a conservar (predeterminado: 10).}
+\item{n}{El número máximo de categorías principales a conservar (predeterminado: 10).}
 
 \item{nom_var}{El nombre para la nueva variable recodificada.}
 

--- a/man/TopRelativo.Rd
+++ b/man/TopRelativo.Rd
@@ -19,7 +19,7 @@ TopRelativo(
 
 \item{var_recode}{Variable que se desea recodificar. Se pasa sin comillas.}
 
-\item{var_top}{Variable a partir de la cual se calcularÃ¡n las frecuencias o la función de resumen. Se pasa sin comillas.}
+\item{var_top}{Variable a partir de la cual se calcularán las frecuencias o la función de resumen. Se pasa sin comillas.}
 
 \item{fun_Top}{La función de resumen a aplicar en caso de no utilizar las frecuencias absolutas (por ejemplo, "mean", "sum", etc.).}
 


### PR DESCRIPTION
## Summary
- fix UTF-8 accents in `TopAbsoluto` and `TopRelativo` documentation
- update corresponding Rd files

## Testing
- `R -q -e "devtools::document()"` *(fails: there is no package called 'devtools')*


------
https://chatgpt.com/codex/tasks/task_e_68bb30e876908331a35db3337ca482d9