### PR TITLE
Validate non-zero multiple in RedondearMultiplo

### DIFF
--- a/R/Numericos.R
+++ b/R/Numericos.R
@@ -68,15 +68,17 @@ Moda <- function(x, na.rm = TRUE) {
 #' La función redondea un número al múltiplo más cercano de un valor especificado, similar a `REDOND.MULT` en Excel.
 #'
 #' @param x Un número. Valor que se desea redondear.
-#' @param multiple Un número. Múltiplo al que se redondeará el valor de \code{x}.
+#' @param multiple Un número. Múltiplo al que se redondeará el valor de \code{x}. Debe ser distinto de 0.
 #'
 #' @return El número redondeado al múltiplo más cercano del valor especificado en \code{multiple}.
+#' @details Si `multiple` es 0, la función lanza un error.
 #' @examples
 #' RedondearMultiplo(453, 100) # Devuelve 500
 #' RedondearMultiplo(1234, 50) # Devuelve 1250
 #'
 #' @export
 RedondearMultiplo <- function(x, multiple) {
+  stopifnot(multiple != 0)
   round(x / multiple) * multiple
 }
 

--- a/man/RedondearMultiplo.Rd
+++ b/man/RedondearMultiplo.Rd
@@ -9,13 +9,16 @@ RedondearMultiplo(x, multiple)
 \arguments{
 \item{x}{Un número. Valor que se desea redondear.}
 
-\item{multiple}{Un número. Múltiplo al que se redondeará el valor de \code{x}.}
+\item{multiple}{Un número. Múltiplo al que se redondeará el valor de \code{x}. Debe ser distinto de 0.}
 }
 \value{
 El número redondeado al múltiplo más cercano del valor especificado en \code{multiple}.
 }
 \description{
 La función redondea un número al múltiplo más cercano de un valor especificado, similar a `REDOND.MULT` en Excel.
+}
+\details{
+Si \code{multiple} es 0, la función lanza un error.
 }
 \examples{
 RedondearMultiplo(453, 100) # Devuelve 500

--- a/tests/testthat/test-numericos.R
+++ b/tests/testthat/test-numericos.R
@@ -1,0 +1,5 @@
+source(file.path("..", "..", "R", "Numericos.R"))
+
+test_that("lanza error cuando multiple es 0", {
+  expect_error(RedondearMultiplo(10, 0))
+})


### PR DESCRIPTION
## Summary
- guard against zero multiples in `RedondearMultiplo`
- document zero multiple error condition
- add test for zero multiple case

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68bb435c91a48331aecddebaf38aa3dd