### PR TITLE
Verificar n en funciones HTML

### DIFF
--- a/R/Html.R
+++ b/R/Html.R
@@ -6,10 +6,13 @@
 #' @return Una cadena de texto que contiene \code{<br/>} repetido \code{n} veces.
 #' @examples
 #' Saltos(3)  # Devuelve "<br/><br/><br/>"
+#' try(Saltos(-1))
+#' try(Saltos(1.5))
 #' @importFrom htmltools HTML
 #' @importFrom magrittr %>%
 #' @export
 Saltos <- function(n = 1) {
+  stopifnot(n >= 0, n == as.integer(n))
   htmltools::HTML(strrep('<br/>', n))
 }
 
@@ -21,8 +24,11 @@ Saltos <- function(n = 1) {
 #' @return Una cadena de texto que contiene \code{&emsp;} repetido \code{n} veces.
 #' @examples
 #' Espacios(4)  # Devuelve "&emsp;&emsp;&emsp;&emsp;"
+#' try(Espacios(-1))
+#' try(Espacios(1.2))
 #' @export
 Espacios <- function(n = 1) {
+  stopifnot(n >= 0, n == as.integer(n))
   htmltools::HTML(strrep('&emsp;', n))
 }
 

--- a/tests/testthat/test-html.R
+++ b/tests/testthat/test-html.R
@@ -1,0 +1,8 @@
+source(file.path('..', '..', 'R', 'Html.R'))
+
+test_that('Saltos y Espacios validan n', {
+  expect_error(Saltos(-1))
+  expect_error(Saltos(1.2))
+  expect_error(Espacios(-1))
+  expect_error(Espacios(1.5))
+})


### PR DESCRIPTION
## Summary
- Validar que `n` sea entero no negativo en `Saltos` y `Espacios`.
- Añadir ejemplos de uso con valores inválidos en la documentación.
- Crear pruebas que confirman el error al pasar valores negativos o decimales.

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(falló: no se encontró el paquete `testthat`)*
- `R -q -e "source('R/Html.R'); try(Saltos(-1))"`
- `R -q -e "source('R/Html.R'); try(Saltos(1.5))"`
- `R -q -e "source('R/Html.R'); try(Espacios(-1))"`
- `R -q -e "source('R/Html.R'); try(Espacios(1.2))"`


------
https://chatgpt.com/codex/tasks/task_e_68bb4364684c8331bff5ab690961ab00