### PR TITLE
Validate date order in EdadCumplida

### DIFF
--- a/R/Fechas.R
+++ b/R/Fechas.R
@@ -108,6 +108,11 @@ EdadCumplida <- function(from, to) {
   from <- as.Date(from)
   to <- as.Date(to)
 
+  # Validar que la fecha final no sea anterior a la inicial
+  if (to < from) {
+    stop("`to` debe ser mayor o igual que `from`")
+  }
+
   # Calcular la diferencia en años utilizando un intervalo
   int <- lubridate::interval(from, to)
   age <- lubridate::time_length(int, "years")

--- a/tests/testthat/test-edad-cumplida.R
+++ b/tests/testthat/test-edad-cumplida.R
@@ -1,0 +1,12 @@
+source(file.path('..', '..', 'R', 'Fechas.R'))
+
+test_that('calcula edad cuando to es posterior', {
+  expect_equal(EdadCumplida(as.Date('1990-01-01'), as.Date('2000-01-01')), 10)
+})
+
+test_that('lanza error cuando to es anterior a from', {
+  expect_error(
+    EdadCumplida(as.Date('2000-01-01'), as.Date('1990-01-01')),
+    '`to` debe ser mayor o igual que `from`'
+  )
+})


### PR DESCRIPTION
## Summary
- ensure EdadCumplida errors when final date precedes start date
- add tests covering normal and inverse date orders

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test-edad-cumplida.R', reporter='summary')"`


------
https://chatgpt.com/codex/tasks/task_e_68bb4360ed2c8331b29f272137ec3b20