### PR TITLE
Evitar valores negativos en pick_opt cuando cho está vacío

### DIFF
--- a/R/Inputs.R
+++ b/R/Inputs.R
@@ -90,7 +90,7 @@ pick_opt <- function(cho, fem = TRUE) {
     `actions-box` = TRUE,                       # Muestra botones de selección/deselección
     `deselect-all-text` = paste("Deseleccionar", tod), # Texto para deseleccionar todos
     `select-all-text` = paste("Seleccionar", tod),     # Texto para seleccionar todos
-    `selected-text-format` = paste0("count > ", length(cho) - 1), # Formato para mostrar la cantidad seleccionada
+    `selected-text-format` = paste0("count > ", max(length(cho) - 1, 0)), # Formato para mostrar la cantidad seleccionada
     `count-selected-text` = tod,                # Texto mostrado al seleccionar todas las opciones
     `none-selected-text` = ""                   # Texto cuando no hay opciones seleccionadas
   )

--- a/tests/testthat/test-inputs.R
+++ b/tests/testthat/test-inputs.R
@@ -11,3 +11,9 @@ test_that("InputNumerico aplica límites", {
   expect_error(InputNumerico("id", "label", 5, min = 6), "config\\$min <= value")
   expect_error(InputNumerico("id", "label", 5, min = 6, max = 3), "config\\$min <= config\\$max")
 })
+
+test_that("pick_opt maneja cho vacío sin valores negativos", {
+  opts <- pick_opt(character(0))
+  val <- as.numeric(sub("count > ", "", opts$`selected-text-format`))
+  expect_true(val >= 0)
+})


### PR DESCRIPTION
## Summary
- Asegura que `pick_opt` use `max(length(cho) - 1, 0)` para evitar conteos negativos cuando no hay opciones
- Añade prueba que verifica que `pick_opt` con `cho` vacío no genere valores negativos

## Testing
- `Rscript -e 'lapply(list.files("R", full.names = TRUE), source); testthat::test_dir("tests/testthat")'`


------
https://chatgpt.com/codex/tasks/task_e_68bb43566d308331b1b24b7a3ddbd714