### PR TITLE
Respeta limites personalizados de porcentaje en InputNumerico

### DIFF
--- a/R/Inputs.R
+++ b/R/Inputs.R
@@ -4,12 +4,18 @@
 #' @param label Etiqueta que describe el campo.
 #' @param value Valor inicial del input.
 #' @param dec Número de decimales a mostrar (por defecto 2).
-#' @param max Valor máximo permitido (por defecto NULL).
-#' @param min Valor mínimo permitido (por defecto NULL).
+#' @param max Valor máximo permitido. Para `type = "porcentaje"` el valor
+#'   por defecto es 100; en otros casos es `NULL`.
+#' @param min Valor mínimo permitido. Para `type = "porcentaje"` el valor
+#'   por defecto es 0; en otros casos es `NULL`.
 #' @param type Tipo de input: "dinero", "porcentaje" o "numero".
 #' @param label_col Ancho de la columna para la etiqueta (por defecto 6).
 #' @param input_col Ancho de la columna para el campo numérico (por defecto 6).
 #' @param width Ancho del control `autonumericInput` (por defecto "100%").
+#'
+#' @details
+#' Cuando `type = "porcentaje"`, el rango permitido por defecto es de 0 a 100.
+#' Estos límites pueden modificarse mediante los argumentos `min` y `max`.
 #'
 #' @return Un objeto de tipo `fluidRow` con el diseño del input.
 #' @examples
@@ -30,11 +36,19 @@ InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, typ
   if (!is.null(min)) stopifnot(is.numeric(min))
 
   # Configuración específica según el tipo de input
-  config <- switch(type,
-                   dinero = list(currencySymbol = "$", decimalPlaces = dec, max = max, min = min),
-                   porcentaje = list(currencySymbol = "%", currencySymbolPlacement = "s", decimalPlaces = 2, max = 100, min = 0),
-                   numero = list(currencySymbol = NULL, decimalPlaces = dec, max = max, min = min),
-                   stop("Tipo de input no soportado. Use 'dinero', 'porcentaje' o 'numero'."))
+  config <- switch(
+    type,
+    dinero = list(currencySymbol = "$", decimalPlaces = dec, max = max, min = min),
+    porcentaje = list(
+      currencySymbol = "%",
+      currencySymbolPlacement = "s",
+      decimalPlaces = 2,
+      max = if (is.null(max)) 100 else max,
+      min = if (is.null(min)) 0 else min
+    ),
+    numero = list(currencySymbol = NULL, decimalPlaces = dec, max = max, min = min),
+    stop("Tipo de input no soportado. Use 'dinero', 'porcentaje' o 'numero'.")
+  )
 
   # Validaciones de rangos
   if (!is.null(config$min) && !is.null(config$max)) {

--- a/man/InputNumerico.Rd
+++ b/man/InputNumerico.Rd
@@ -26,9 +26,9 @@ InputNumerico(
 
 \item{dec}{Número de decimales a mostrar (por defecto 2).}
 
-\item{max}{Valor máximo permitido (por defecto NULL).}
+\item{max}{Valor máximo permitido. Para `type = "porcentaje"` el valor por defecto es 100; en otros casos es `NULL`.}
 
-\item{min}{Valor mínimo permitido (por defecto NULL).}
+\item{min}{Valor mínimo permitido. Para `type = "porcentaje"` el valor por defecto es 0; en otros casos es `NULL`.}
 
 \item{type}{Tipo de input: "dinero", "porcentaje" o "numero".}
 
@@ -37,6 +37,9 @@ InputNumerico(
 \item{input_col}{Ancho de la columna para el campo numérico (por defecto 6).}
 
 \item{width}{Ancho del control `autonumericInput` (por defecto "100%").}
+}
+\details{
+Cuando `type = "porcentaje"`, el rango permitido por defecto es de 0 a 100. Estos límites pueden modificarse mediante los argumentos `min` y `max`.
 }
 \value{
 Un objeto de tipo `fluidRow` con el diseño del input.

--- a/tests/testthat/test-inputs.R
+++ b/tests/testthat/test-inputs.R
@@ -1,4 +1,5 @@
 source(file.path("..", "..", "R", "Inputs.R"))
+source(file.path("..", "..", "R", "Formatos.R"))
 
 test_that("InputNumerico valida argumentos numéricos", {
   expect_error(InputNumerico("id", "label", "a"), "is\\.numeric\\(value\\)")
@@ -10,4 +11,21 @@ test_that("InputNumerico aplica límites", {
   expect_error(InputNumerico("id", "label", 5, max = 4), "value <= config\\$max")
   expect_error(InputNumerico("id", "label", 5, min = 6), "config\\$min <= value")
   expect_error(InputNumerico("id", "label", 5, min = 6, max = 3), "config\\$min <= config\\$max")
+})
+
+test_that("InputNumerico respeta rangos personalizados de porcentaje", {
+  # Rangos por defecto 0-100
+  expect_error(InputNumerico("id", "label", 101, type = "porcentaje"), "value <= config\\$max")
+  expect_error(InputNumerico("id", "label", -1, type = "porcentaje"), "config\\$min <= value")
+
+  # Rango personalizado
+  expect_error(InputNumerico("id", "label", 60, type = "porcentaje", max = 50, min = -50), "value <= config\\$max")
+  expect_error(InputNumerico("id", "label", -60, type = "porcentaje", max = 50, min = -50), "config\\$min <= value")
+
+  # Solo max personalizado
+  expect_error(InputNumerico("id", "label", 210, type = "porcentaje", max = 200), "value <= config\\$max")
+  expect_error(InputNumerico("id", "label", -1, type = "porcentaje", max = 200), "config\\$min <= value")
+
+  # Solo min personalizado
+  expect_error(InputNumerico("id", "label", 5, type = "porcentaje", min = 10), "config\\$min <= value")
 })


### PR DESCRIPTION
## Summary
- Permite que `InputNumerico` use los valores `min` y `max` proporcionados para tipo `porcentaje`, manteniendo por defecto el rango 0-100.
- Documentación actualizada para reflejar los nuevos límites configurables.
- Pruebas que validan diversos rangos personalizados de porcentaje.

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test-inputs.R')"`


------
https://chatgpt.com/codex/tasks/task_e_68bb4352f7e48331a38fbbab66a106a2