### PR TITLE
Allow NULL/NA defaults in InputNumerico

### DIFF
--- a/R/Inputs.R
+++ b/R/Inputs.R
@@ -2,7 +2,7 @@
 #'
 #' @param id Identificador único del input.
 #' @param label Etiqueta que describe el campo.
-#' @param value Valor inicial del input.
+#' @param value Valor inicial del input. Puede ser `NULL` o `NA`.
 #' @param dec Número de decimales a mostrar (por defecto 2).
 #' @param max Valor máximo permitido. Para `type = "porcentaje"` el valor
 #'   por defecto es 100; en otros casos es `NULL`.
@@ -16,6 +16,7 @@
 #' @details
 #' Cuando `type = "porcentaje"`, el rango permitido por defecto es de 0 a 100.
 #' Estos límites pueden modificarse mediante los argumentos `min` y `max`.
+#' Si `value` es `NULL` o `NA`, las validaciones de rango se omiten.
 #'
 #' @return Un objeto de tipo `fluidRow` con el diseño del input.
 #' @export
@@ -32,7 +33,7 @@ InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, typ
   type <- match.arg(type, c("dinero", "porcentaje", "numero"))
 
   # Validaciones de tipo de datos
-  stopifnot(is.numeric(value))
+  stopifnot(is.numeric(value) || is.null(value) || (length(value) == 1 && is.na(value)))
   if (!is.null(max)) stopifnot(is.numeric(max))
   if (!is.null(min)) stopifnot(is.numeric(min))
 
@@ -52,13 +53,15 @@ InputNumerico <- function(id, label, value, dec = 2, max = NULL, min = NULL, typ
   )
 
   # Validaciones de rangos
-  if (!is.null(config$min) && !is.null(config$max)) {
-    stopifnot(config$min <= config$max)
-    stopifnot(config$min <= value, value <= config$max)
-  } else if (!is.null(config$min)) {
-    stopifnot(config$min <= value)
-  } else if (!is.null(config$max)) {
-    stopifnot(value <= config$max)
+  if (!is.null(value) && !(length(value) == 1 && is.na(value))) {
+    if (!is.null(config$min) && !is.null(config$max)) {
+      stopifnot(config$min <= config$max)
+      stopifnot(config$min <= value, value <= config$max)
+    } else if (!is.null(config$min)) {
+      stopifnot(config$min <= value)
+    } else if (!is.null(config$max)) {
+      stopifnot(value <= config$max)
+    }
   }
 
   # Construcción del componente visual

--- a/man/InputNumerico.Rd
+++ b/man/InputNumerico.Rd
@@ -22,7 +22,7 @@ InputNumerico(
 
 \item{label}{Etiqueta que describe el campo.}
 
-\item{value}{Valor inicial del input.}
+\item{value}{Valor inicial del input. Puede ser `NULL` o `NA`.}
 
 \item{dec}{Número de decimales a mostrar (por defecto 2).}
 
@@ -39,7 +39,7 @@ InputNumerico(
 \item{width}{Ancho del control `autonumericInput` (por defecto "100%").}
 }
 \details{
-Cuando `type = "porcentaje"`, el rango permitido por defecto es de 0 a 100. Estos límites pueden modificarse mediante los argumentos `min` y `max`.
+Cuando `type = "porcentaje"`, el rango permitido por defecto es de 0 a 100. Estos límites pueden modificarse mediante los argumentos `min` y `max`. Si `value` es `NULL` o `NA`, las validaciones de rango se omiten.
 }
 \value{
 Un objeto de tipo `fluidRow` con el diseño del input.

--- a/tests/testthat/test-inputs.R
+++ b/tests/testthat/test-inputs.R
@@ -7,6 +7,15 @@ test_that("InputNumerico valida argumentos numéricos", {
   expect_error(InputNumerico("id", "label", 1, min = "10"), "is\\.numeric\\(min\\)")
 })
 
+test_that("InputNumerico permite value NULL y NA", {
+  skip_if_not("autonumericInput" %in% getNamespaceExports("shiny"),
+    "autonumericInput no disponible")
+  expect_error(InputNumerico("id", "label", NULL), NA)
+  expect_error(InputNumerico("id", "label", NA), NA)
+  expect_error(InputNumerico("id", "label", NULL, min = 0, max = 10), NA)
+  expect_error(InputNumerico("id", "label", NA, min = 0, max = 10), NA)
+})
+
 test_that("InputNumerico aplica límites", {
   expect_error(InputNumerico("id", "label", 5, max = 4), "value <= config\\$max")
   expect_error(InputNumerico("id", "label", 5, min = 6), "config\\$min <= value")


### PR DESCRIPTION
## Summary
- allow `InputNumerico` to accept `NULL`/`NA` values and skip range validation in that case
- document that `value` may be `NULL` or `NA`
- add tests for `NULL`/`NA` values (skipped if `autonumericInput` missing)

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: Moda(), TopAbsoluto(), TopRelativo() missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dcef1d1c833196491348e1804a26