### PR TITLE
Fix ListaDesplegable picker options definition

### DIFF
--- a/R/Inputs.R
+++ b/R/Inputs.R
@@ -152,9 +152,8 @@ ListaDesplegable <- function(inputId, label = NULL, choices, selected = choices,
   nin <- ifelse(fem, "Ninguna", "Ninguno")
   sel <- ifelse(fem, "seleccionadas", "seleccionados")
 
-<<<<<<< HEAD
   # Opciones del picker
-  picker_options <- pickerOptions(
+  picker_options <- shinyWidgets::pickerOptions(
     liveSearch            = TRUE,
     liveSearchNormalize   = TRUE,
     liveSearchPlaceholder = "Buscar...",
@@ -167,17 +166,6 @@ ListaDesplegable <- function(inputId, label = NULL, choices, selected = choices,
     showTick              = TRUE,
     width                 = "100%",
     style                 = "btn-default"
-=======
-  # Lista de opciones configurables para selectPicker
-  res <- list(
-    `live-search` = TRUE,                       # Habilita la búsqueda en vivo
-    `actions-box` = TRUE,                       # Muestra botones de selección/deselección
-    `deselect-all-text` = paste("Deseleccionar", tod), # Texto para deseleccionar todos
-    `select-all-text` = paste("Seleccionar", tod),     # Texto para seleccionar todos
-    `selected-text-format` = paste0("count > ", max(length(cho) - 1, 0)), # Formato para mostrar la cantidad seleccionada
-    `count-selected-text` = tod,                # Texto mostrado al seleccionar todas las opciones
-    `none-selected-text` = ""                   # Texto cuando no hay opciones seleccionadas
->>>>>>> 16711784c5872c0621e7a759c364100e04813725
   )
 
   # CSS personalizado


### PR DESCRIPTION
## Summary
- remove merge conflict markers from `R/Inputs.R`
- ensure `ListaDesplegable()` uses `shinyWidgets::pickerOptions` for a consistent picker configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe2999f788331ad49ca68ecda1027